### PR TITLE
Rollbar collector first draft

### DIFF
--- a/collectors/0/rollbar.py
+++ b/collectors/0/rollbar.py
@@ -2,7 +2,9 @@
 
 """A collector to gather statistics from Rollbar (https://rollbar.com)
 
-For now, set your access token via environment variable: ROLLBAR_TOKEN
+For now, set your access tokens via environment variable: ROLLBAR_TOKEN
+To watch more than one project, separate each project access token with
+a space.
 """
 
 import json
@@ -11,70 +13,122 @@ import sys
 import time
 import urllib
 import urllib2
+import re
 
 from collectors.lib import utils
-
-TOKEN = os.environ["ROLLBAR_TOKEN"]
 
 def dbg(s):
 	sys.stderr.write(s+"\n")
 
+def scrub_metric_name(s):
+	return re.sub(r'[^a-zA-Z0-9_\.\-]', '', s)
+
 def main():
+	tokens_packed = os.environ["ROLLBAR_TOKEN"]
+
 	utils.drop_privileges()
 	sys.stdin.close()
 
 	interval = 15
 
-	if not TOKEN:
+	if not tokens_packed:
 		raise ValueError("ROLLBAR_TOKEN envoinment variable not found")
 
-	# get the most recent occurance ID number, so we can then check every 15 seconds for any new ones since.
-	first_list = instances(1)
+	projects = []
 
-	since_id = first_list[0]["id"]
-	if not since_id:
-		raise RuntimeError("Instance without ID returned")
+	for token in tokens_packed.split(" "):
+		project_info = project_call(token)
+		project_info["token"] = token
+		project_info["envs"] = {}
+		projects.append(project_info)
+
+	# get the most recent occurance ID number, so we can then check every 15 seconds for any new ones since.
+	for p in projects:
+		first_list = instances_call(p["token"], 1)
+
+		since_id = first_list[0]["id"]
+		if not since_id:
+			raise RuntimeError("Instance without ID returned")
+
+		p["since_id"] = since_id
 
 	while True:
 		time.sleep(interval)
 
-		count = 0
-		page = 1
-		new_since = ""
+		ts = int(time.time())
 
-		more = True
-		while more:
-			l = instances(page)
-			for instance in l:
-				if not instance["id"]:
-					raise RuntimeError("Instance without ID returned")
+		for p in projects:
 
-				if new_since == "":
-					new_since = instance["id"]
+			p_metric = scrub_metric_name(p["name"])
 
-				if instance["id"] == since_id:
-					since_id = new_since
+			page = 1
+			new_since = ""
+			env_counts = {}
+			for e in p["envs"]:
+				env_counts[e] = 0
+
+			more = True
+			while more:
+				l = instances_call(p["token"], page)
+				for instance in l:
+					if not instance["id"]:
+						raise RuntimeError("Instance without ID returned")
+
+					if new_since == "":
+						new_since = instance["id"]
+
+					if instance["id"] <= p["since_id"]:
+						p["since_id"] = new_since
+						more = False
+						break
+
+					e = instance["data"].get("environment", "")
+					if not e:
+						e = "unknown"
+
+					if not env_counts.get(e, 0):
+						env_counts[e] = 1
+						p["envs"][e] = True
+					else:
+						env_counts[e] += 1
+
+				if page > 99:
+					dbg("Whoa, wayy too much stuff coming back (" + page + " pages)")
 					more = False
 					break
 
-				count += 1
+				page += 1
 
-			if page > 10:
-				raise RuntimeError("Whoa, wayy too much stuff coming back")
+			for e in env_counts:
+				e_metric = scrub_metric_name(e)
+				print("rollbar.occurences %d %d env=%s project=%s" % (ts, env_counts[e], e_metric, p_metric))
 
-			page += 1
-
-		ts = int(time.time())
-		print("rollbar.occurences.total %d %d" % (ts, count))
 		sys.stdout.flush()
 
-def instances(page):
+
+def instances_call(token, page):
 	args = {
-		"access_token": TOKEN,
+		"access_token": token,
 		"page": page,
 	}
 
-	url = "https://api.rollbar.com/api/1/instances/?" + urllib.urlencode(args)
+	res = rollbar_call("/api/1/instances/", args)
+
+	if not res["instances"]:
+		raise RuntimeError("No result \"instances\" returned")
+
+	return res["instances"]
+
+def project_call(token):
+	args = {
+		"access_token": token,
+	}
+
+	return rollbar_call("/api/1/project/", args)
+
+def rollbar_call(uri, args):
+	url = "https://api.rollbar.com" + uri + "?" + urllib.urlencode(args)
+
 	#dbg(url)
 
 	req = urllib2.urlopen(url)
@@ -87,11 +141,7 @@ def instances(page):
 	if not obj["result"]:
 		raise RuntimeError("No \"result\" returned")
 
-	if not obj["result"]["instances"]:
-		raise RuntimeError("No result \"instances\" returned")
-
-	return obj["result"]["instances"]
-
+	return obj["result"]
 
 if __name__ == "__main__":
 	sys.exit(main())

--- a/collectors/0/rollbar.py
+++ b/collectors/0/rollbar.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python2
+
+"""A collector to gather statistics from Rollbar (https://rollbar.com)
+
+For now, set your access token via environment variable: ROLLBAR_TOKEN
+"""
+
+import json
+import os
+import sys
+import time
+import urllib
+import urllib2
+
+from collectors.lib import utils
+
+TOKEN = os.environ["ROLLBAR_TOKEN"]
+
+def dbg(s):
+	sys.stderr.write(s+"\n")
+
+def main():
+	utils.drop_privileges()
+	sys.stdin.close()
+
+	interval = 15
+
+	if not TOKEN:
+		raise ValueError("ROLLBAR_TOKEN envoinment variable not found")
+
+	# get the most recent occurance ID number, so we can then check every 15 seconds for any new ones since.
+	first_list = instances(1)
+
+	since_id = first_list[0]["id"]
+	if not since_id:
+		raise RuntimeError("Instance without ID returned")
+
+	while True:
+		time.sleep(interval)
+
+		count = 0
+		page = 1
+		new_since = ""
+
+		more = True
+		while more:
+			l = instances(page)
+			for instance in l:
+				if not instance["id"]:
+					raise RuntimeError("Instance without ID returned")
+
+				if new_since == "":
+					new_since = instance["id"]
+
+				if instance["id"] == since_id:
+					since_id = new_since
+					more = False
+					break
+
+				count += 1
+
+			if page > 10:
+				raise RuntimeError("Whoa, wayy too much stuff coming back")
+
+			page += 1
+
+		ts = int(time.time())
+		print("rollbar.occurences.total %d %d" % (ts, count))
+		sys.stdout.flush()
+
+def instances(page):
+	args = {
+		"access_token": TOKEN,
+		"page": page,
+	}
+
+	url = "https://api.rollbar.com/api/1/instances/?" + urllib.urlencode(args)
+	#dbg(url)
+
+	req = urllib2.urlopen(url)
+	obj = json.loads(req.read())
+	req.close()
+
+	if obj["err"]:
+		raise RuntimeError(obj["err"])
+
+	if not obj["result"]:
+		raise RuntimeError("No \"result\" returned")
+
+	if not obj["result"]["instances"]:
+		raise RuntimeError("No result \"instances\" returned")
+
+	return obj["result"]["instances"]
+
+
+if __name__ == "__main__":
+	sys.exit(main())


### PR DESCRIPTION
For now this is just a count of item occurrences in a single rollbar
project, across all environments. More fine grained control is needed.
Ideally you would give it a list of access tokens, in order to get stats
from multiple projects, and it would be nice to use the project name
somewhere in the stat (or as a tag).

Also this needs some sort of sanity check to prevent endless fetches if
for some reason rollbar doesn't send an item back with a certain id.
Maybe a better check would be greater than/less than, rather than
equals.
